### PR TITLE
Remove ref-array as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "bindings": "~1.2.0",
     "nan": "~1.1.0",
-    "mocha": "*",
-    "ref-array": "~0.0.3"
+    "mocha": "*"
   }
 }


### PR DESCRIPTION
Ref-array cannot be build with node 0.12.0 Also it is rebuild with node 0.10 which requires to have VisualStudio installed on Windows.